### PR TITLE
Fix the CVE-2018-10237 fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>24.1.1</version>
+            <version>30.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.vmware.xenon</groupId>


### PR DESCRIPTION
Shouldn't have blindedly trusted dependabot.